### PR TITLE
Update Broken Website Links For DPGs in Registry

### DIFF
--- a/nominees/feed-the-monster.json
+++ b/nominees/feed-the-monster.json
@@ -1,7 +1,7 @@
 {
   "name": "Feed The Monster",
   "description": "Feed The Monster teaches your child the fundamentals of reading. Collect monster eggs and feed them letters so they can grow into new friends! Available in 48 languages.",
-  "website": "https://play.google.com/store/apps/developer?id=Curious%20Learning",
+  "website": "https://www.feedthemonsterapp.com/",
   "license": [
     {
       "spdx": "BSD-2-Clause",

--- a/nominees/global-digital-library.json
+++ b/nominees/global-digital-library.json
@@ -4,7 +4,7 @@
     "GDL"
   ],
   "description": "An open collection of high-quality educational reading resources, making them available on the web, mobile and for print.",
-  "website": "https://home.digitallibrary.io/",
+  "website": "https://digitallibrary.io",
   "license": [
     {
       "spdx": "CC-BY-3.0",

--- a/nominees/statbus.json
+++ b/nominees/statbus.json
@@ -4,7 +4,7 @@
     "SBR"
   ],
   "description": "Statistical Business Register IT system",
-  "website": "https://statbus.org",
+  "website": "https://www.statbus.org/",
   "license": [
     {
       "spdx": "Apache-2.0",

--- a/nominees/vrapeutic.json
+++ b/nominees/vrapeutic.json
@@ -4,7 +4,7 @@
     ""
   ],
   "description": "VRapeutic develops virtual reality software modules specially tailored to instill cognitive, social, academic, and motor skills in children and young adults. Our ever-growing library of modules empowers therapists with unlimited virtual rehabilitation scenarios, in addition to providing them cutting-edge technologies to track children’s performance and design data-driven rehabilitation plans. VRapeutic's vision is to develop the largest science-backed VR curricula for essential life skills worldwide.",
-  "website": "https://www.linkedin.com/company/vrapeutic",
+  "website": "https://myvrapeutic.com/",
   "license": [
     {
       "spdx": "GPL-3.0",


### PR DESCRIPTION
Update broken links for the following DPGs:

- [Feed The Monster](https://www.feedthemonsterapp.com/)
- [Global Digital Library](https://digitallibrary.io)
- [Vrapeutic](https://myvrapeutic.com/)
- [Statbus](https://www.statbus.org/)
- [Bisa Health](https://bisaapp.com/)
- [Accessible Kazakhstan](https://doskaz.kz/en)