### PR TITLE
BLD: automatic addition of new website pages

### DIFF
--- a/scripts/push.bash
+++ b/scripts/push.bash
@@ -27,7 +27,7 @@ git clone https://github.com/DPGAlliance/publicgoods-website.git ../publicgoods-
     git config --global user.name "dpgabot" && \
     pushd ../publicgoods-website && \
         git remote set-url origin https://${GITHUB_TOKEN}@github.com/DPGAlliance/publicgoods-website.git && \
-        git add author blog category registry tag && \
+        git add . && \
         git stash && git pull --rebase && git stash pop && \
         git commit -am "BLD: $GITHUB_SHA" || true && \
         git push --set-upstream origin main


### PR DESCRIPTION
This PR introduces a very small but practical change: whenever @SarahWat or @Not-Whiskey create a new page in the Heroku Wordpress instance, the deployment of https://digitalpublicgoods.net will automatically add them and publish them, whereas before they had to be manually added (usually by me). 

By running `git add .`, git will add all new files in that (website) folder. I have tested this successfully in my local environment.