### PR TITLE
Update nominee: Lily the Llama Helps Her Herd

### DIFF
--- a/nominees/lily-the-llama-helps-her-herd.json
+++ b/nominees/lily-the-llama-helps-her-herd.json
@@ -7,7 +7,7 @@
   "website": "https://digitalmedic.stanford.edu/3d-flip-book/lily-the-llama-helps-her-herd/",
   "license": [
     {
-      "spdx": "CC-BY-4.0",
+      "spdx": "CC-BY-NC-SA-4.0",
       "licenseURL": "https://digitalmedic.stanford.edu/3d-flip-book/lily-the-llama-helps-her-herd/"
     }
   ],


### PR DESCRIPTION
Digital public goods must use an open license. Lily the Llama Helps Her Herd prior to this update was using a license that was not part of the approved OSI Licenses. This pull request addresses that issue by updating from `CC-BY-NC-ND 4.0` to `CC-BY-NC-SA-4.0`