### PR TITLE
BUG: rename lookingglass

### DIFF
--- a/digitalpublicgoods/lookingglass.json
+++ b/digitalpublicgoods/lookingglass.json
@@ -1,5 +1,5 @@
 {
-  "name": "Looking Glass",
+  "name": "LookingGlass",
   "clearOwnership": {
     "isOwnershipExplicit": "Yes",
     "copyrightURL": "https://github.com/gnif/LookingGlass/blob/master/AUTHORS"


### PR DESCRIPTION
There was a mismatch between the naming of the files of `nominees/lookingglass.json` and `digitalpublicgoods/looking-glass.json` (note the `-` difference) that was causing the build to fail. This fixes it.