### PR TITLE
Add license: OGL-UK-3.0

### DIFF
--- a/nominee-schema.json
+++ b/nominee-schema.json
@@ -151,6 +151,7 @@
               "OFL-1.1",
               "OFL-1.1-no-RFN",
               "OFL-1.1-RFN",
+              "OGL-UK-3.0",
               "OGTSL",
               "OLDAP-2.8",
               "OSET-PL-2.1",


### PR DESCRIPTION
This PR addresses an issue in #958. 

FYI - Version 3.0 of the license carries the SPDX identifier [OGL-UK-3.0](https://en.wikipedia.org/wiki/Open_Government_Licence) as indicated in the license section.