### PR TITLE
Updates/Fixes to E-Heza Nomination

### DIFF
--- a/nominees/e-heza.json
+++ b/nominees/e-heza.json
@@ -8,7 +8,7 @@
   "license": [
     {
       "spdx": "Apache-2.0",
-      "licenseURL": "https://github.com/TIP-Global-Health/eheza-app"
+      "licenseURL": "https://github.com/TIP-Global-Health/eheza-app/blob/main/LICENSE.txt"
     }
   ],
   "SDGs": [

--- a/nominees/e-heza.json
+++ b/nominees/e-heza.json
@@ -37,7 +37,7 @@
       "website": "https://tipglobalhealth.org/",
       "org_type": "maintainer",
       "contact_name": "Dr. Wendy Leonard",
-      "contact_email": "wendy@tipglobalheath.org"
+      "contact_email": "wendy@tipglobalhealth.org"
     }
   ],
   "stage": "nominee"


### PR DESCRIPTION
Fixes 
- link to open source (Apache 2.0) license
- typo in maintainer email address.