### PR TITLE
Update DPG: RapidPro

### DIFF
--- a/digitalpublicgoods/rapidpro.json
+++ b/digitalpublicgoods/rapidpro.json
@@ -14,7 +14,7 @@
     "documentationURL": [
       "Technical documentation: https://rapidpro.github.io/rapidpro/docs/",
       "API Explorer: https://rapidpro.io/api/v2/explorer/",
-      "FAQs: https://community.rapidpro.io/faqs/"
+      "FAQs: https://community.rapidpro.io/faqs-1/"
     ]
   },
   "NonPII": {


### PR DESCRIPTION
FAQs link was update to a different URL