### PR TITLE
Update DPG: Mojaloop

### DIFF
--- a/digitalpublicgoods/mojaloop.json
+++ b/digitalpublicgoods/mojaloop.json
@@ -2,7 +2,7 @@
   "name": "Mojaloop",
   "clearOwnership": {
     "isOwnershipExplicit": "Yes",
-    "copyrightURL": "https://docs.mojaloop.io/documentation/mojaloop-background/ \n https://mojaloop.io/terms-of-use/"
+    "copyrightURL": "https://mojaloop.io/terms-of-use/"
   },
   "platformIndependence": {
     "mandatoryDepsCreateMoreRestrictions": "No",


### PR DESCRIPTION
Remove ownership evidence link that is no longer available, terms of use are still valid and serve this purpose.