### PR TITLE
Re-review DPG: VIPS

### DIFF
--- a/nominees/vips.json
+++ b/nominees/vips.json
@@ -5,7 +5,7 @@
   "license": [
     {
       "spdx": "AGPL-3.0",
-      "licenseURL": "https://nibio.no/en/about-eng/software-licenses-and-agreements"
+      "licenseURL": "https://gitlab.nibio.no/VIPS/VIPSCore/-/blob/develop/LICENSE.txt"
     }
   ],
   "SDGs": [


### PR DESCRIPTION
Some considerations for this re-review:

1. I think licensing field should point out to the LICENSE file within the specific digital solution source code. (This PR updates license link to core VIPS repository)
2. It has it's own license based on GNU APL 3.0 but with one difference.

https://nibio.no/en/about-eng/software-licenses-and-agreements

> NIBIO Open Source License
> This License is specific for the VIPS project. It's based on the GNU Affero Public License v3, and differs only on one significant matter: Models developed for VIPS do not need to be Open Source Licensed in order to be combined with the VIPS Platform software.

