### PR TITLE
Update GitHub action file-changes-action to v1.2.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.3
+        uses: trilom/file-changes-action@v1.2.4
       - name: Install dependencies
         run:
           npm install


### PR DESCRIPTION
Bumping file-changes-action to v1.2.4 in order to address a discovered bug when looking for changes in file names.

This can be seen in the recent build failures for the DPG API in [this action output](https://github.com/DPGAlliance/publicgoods-candidates/actions/runs/3424786677/jobs/5705009462#step:3:1) as archived nominees from [this commit](https://github.com/DPGAlliance/publicgoods-candidates/pull/1456) are seen a name change which triggered the error.

The related issue for this can be seen [here](https://github.com/trilom/file-changes-action/issues/100)

This merge would only affect the building of the DPG API as it is the only thing currently being affected during deployment.