### PR TITLE
Updated push script to match new registry build updates

### DIFF
--- a/scripts/push.bash
+++ b/scripts/push.bash
@@ -5,9 +5,10 @@ git clone https://github.com/DPGAlliance/publicgoods-website.git ../publicgoods-
         npm install && \
         ./scripts/static.bash && \
         pushd packages/automation && \
-            node generate_dpgs.js && \
-            node index.js && \
-            node generate_nominees.js && \
+        node consolidate_data.js && \
+        popd && \
+        pushd packages/automation && \
+        node index.js && \
         popd && \
         pushd packages/registry && \
             npm run build && \


### PR DESCRIPTION
This PR:
- Updates `push.bash` build script to that of the new build process from the `publicgoods-scripts` repository.