### PR TITLE
disable map build

### DIFF
--- a/scripts/push.bash
+++ b/scripts/push.bash
@@ -16,9 +16,9 @@ git clone https://github.com/DPGAlliance/publicgoods-website.git ../publicgoods-
         pushd packages/eligibility && \
             npm run build && \
         popd && \
-        pushd packages/map && \
-            npm run build && \
-        popd && \
+        #pushd packages/map && \
+        #    npm run build && \
+        #popd && \
         pushd packages/roadmap && \
             npm run build && \
         popd && \


### PR DESCRIPTION
Temporarily disabling build of maps package as it is causing deployment errors