### PR TITLE
Deprecate actions workflow for new deployment process

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -1,25 +1,25 @@
-name: Automatic Build
+# name: Automatic Build
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
+# on:
+#   workflow_dispatch:
+#   schedule:
+#     - cron: '0 0 * * *'
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+# jobs:
+#   deploy:
+#     runs-on: ubuntu-latest
+#     if: github.ref == 'refs/heads/main'
 
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-      - name: Install dependecies
-        run: npm install
-      - name: Deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN}}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
-          NEXT_PUBLIC_SHEET_ID: ${{ secrets.NEXT_PUBLIC_SHEET_ID }}
-        run: ./scripts/push.bash
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions/setup-node@v2
+#         with:
+#           node-version: '16'
+#       - name: Install dependecies
+#         run: npm install
+#       - name: Deploy
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN}}
+#           NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
+#           NEXT_PUBLIC_SHEET_ID: ${{ secrets.NEXT_PUBLIC_SHEET_ID }}
+#         run: ./scripts/push.bash


### PR DESCRIPTION
This PR:

- Deprecates the current nightly build process for the DPG website using this `publicgoods-candidates` repo

- This is in favour of a new deployment process which would center around the `publicgoods-scripts` repo

- The current actions script would be present in the new process in the `publicgoods-scripts` repo